### PR TITLE
Fix: Total Income & Expense showed false value while pagination works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+
+/.idea

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/Http/Controllers/ExpenseController.php
+++ b/app/Http/Controllers/ExpenseController.php
@@ -11,6 +11,7 @@ class ExpenseController extends Controller
     public function index()
     {
         $data['expenses'] = Expense::where('user_id', Auth::user()->id)->latest()->paginate(12);
+        $data['totalExpenses'] = Expense::where('user_id', Auth::user()->id)->sum('expense_amount');
 
         return view('pages.expenses.index', $data);
     }

--- a/app/Http/Controllers/IncomeController.php
+++ b/app/Http/Controllers/IncomeController.php
@@ -15,6 +15,7 @@ class IncomeController extends Controller
     public function index()
     {
         $data['incomes'] = Income::where('user_id', Auth::user()->id)->latest()->paginate(12);
+        $data['totalIncomes'] = Income::where('user_id', Auth::user()->id)->sum('income_amount');
 
         return view('pages.incomes.index', $data);
     }

--- a/resources/views/pages/expenses/index.blade.php
+++ b/resources/views/pages/expenses/index.blade.php
@@ -23,7 +23,7 @@
 				  </li>
 				  <li class="list-group-item d-flex justify-content-between align-items-center">
 				    Total Expense
-				    <span class="badge badge-danger badge-pill">{{ $expenses->sum('expense_amount') }}</span>
+                      <span class="badge badge-danger badge-pill">{{ $totalExpenses }}</span>
 				  </li>
 				</ul>
         	</div>

--- a/resources/views/pages/incomes/index.blade.php
+++ b/resources/views/pages/incomes/index.blade.php
@@ -24,7 +24,7 @@
 				  </li>
 				  <li class="list-group-item d-flex justify-content-between align-items-center">
 				    Total Income
-				    <span class="badge badge-primary badge-pill">{{ $incomes->sum('income_amount') }}</span>
+                      <span class="badge badge-primary badge-pill">{{ $totalIncomes }}</span>
 				  </li>
 				</ul>
         	</div>


### PR DESCRIPTION
When Pagination active The total Expense & Income amount just showing the total amount of the current page.